### PR TITLE
Fix _url_for method

### DIFF
--- a/giftless_client/client.py
+++ b/giftless_client/client.py
@@ -2,7 +2,6 @@
 """
 import hashlib
 import logging
-import os
 from typing import Any, BinaryIO, Dict, Iterable, List, Optional
 
 import requests
@@ -96,7 +95,7 @@ class LfsClient(object):
 
     def _url_for(self, *segments, **params):
         # type: (str, str) -> str
-        path = os.path.join(*segments)
+        path = '/'.join(segments)
         url = '{url}/{path}'.format(url=self._url, path=path)
         if params:
             url = '{url}?{params}'.format(url=url, params=urllib_parse.urlencode(params))


### PR DESCRIPTION
`client._url_for(...)` method is not working when using from a windows machine since it builds a url path using `\`.

```
> c:\users\jessicach\anaconda3\lib\site-packages\giftless_client\client.py(99)_url_for()
98 # type: (str, str) -> str
---> 99 path = os.path.join(*segments)
100 url = '{url}/{path}'.format(url=self._url, path=path)

os.path.join(*segments)
'gdx/6ff16dab-74cd-4730-ab61-255a7e6b752a\\objects\\batch'
```