### PR TITLE
Support for generic Git LFS servers, Basic Auth and listing locks

### DIFF
--- a/giftless_client/__init__.py
+++ b/giftless_client/__init__.py
@@ -1,4 +1,5 @@
 from .client import LfsClient
+from .exc import LfsError
 
 __version__ = '0.1.1'
-__all__ = ['__version__', 'LfsClient']
+__all__ = ['__version__', 'LfsClient', 'LfsError']


### PR DESCRIPTION
This PR adds three things:
- Support for generic Git LFS servers that do not use org/repo prefixes
- A method to list locks (raw). I pretty much only needed this for a basic way to check connectivity without uploading/downloading, so it doesn't do much more than that.
- Support for authenticating via HTTP Basic Auth.